### PR TITLE
Add missing test coverage

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import functools
 import queue
+import time
 import unittest
-
-import oxia
 import uuid
 
+import oxia
+from oxia.internal.compare import compare_with_slash
 from oxia.internal.oxia_container import OxiaContainer
+from oxia.internal.proto.io.streamnative.oxia import proto as pb
 
 
 def new_key():
@@ -239,6 +242,21 @@ class OxiaClientTestCase(unittest.TestCase):
         with OxiaContainer(shards=10) as server:
             client = oxia.Client(server.service_url())
             k = new_key()
+
+            # The cross-shard floor/ceiling merge in Client.get() is the
+            # code path under test. If all five keys happen to hash to the
+            # same shard, the test degrades to a single-shard scenario and
+            # silently stops covering that merge. Assert the spread up front.
+            sd = client._service_discovery
+            shards_used = {
+                sd.get_shard(k + suffix).shard
+                for suffix in ['/a', '/c', '/d', '/e', '/g']
+            }
+            self.assertGreater(
+                len(shards_used), 1,
+                f"test keys must span multiple shards to exercise cross-shard logic; "
+                f"got {shards_used}")
+
             client.put(k + "/a", '0')
             # client.put(k + "/b", '1') # Skipped intentionally
             client.put(k + "/c", '2')
@@ -708,23 +726,27 @@ class OxiaClientTestCase(unittest.TestCase):
             with self.assertRaises(oxia.ex.InvalidOptions):
                 client.get_sequence_updates("a")
 
-            # gs1 = client.get_sequence_updates("a", partition_key="x")
-            # gs1.close()
+            # Subscribe-then-immediately-close, before any data exists.
+            gs1 = client.get_sequence_updates("a", partition_key="x")
+            gs1.close()
 
             k1, _ = client.put('a', '0', sequence_keys_deltas=[1], partition_key='x')
             self.assertEqual('a-%020d' % 1, k1)
             k2, _ = client.put('a', '0', sequence_keys_deltas=[1], partition_key='x')
             self.assertEqual('a-%020d' % 2, k2)
 
-            # gs2 = client.get_sequence_updates("a", partition_key="x")
-            # self.assertEqual(k2, next(gs2))
-            # gs2.close()
+            # A fresh subscription must receive the current highest sequence as
+            # the first event (not wait for the next write).
+            gs2 = client.get_sequence_updates("a", partition_key="x")
+            self.assertEqual(k2, next(gs2))
+            gs2.close()
 
             k3, _ = client.put('a', '0', sequence_keys_deltas=[1], partition_key='x')
             self.assertEqual('a-%020d' % 3, k3)
 
-            # with self.assertRaises(StopIteration):
-            #     next(gs2)
+            # After close, the iterator must be exhausted.
+            with self.assertRaises(StopIteration):
+                next(gs2)
 
             gs3 = client.get_sequence_updates("a", partition_key="x")
             self.assertEqual(k3, next(gs3))
@@ -733,7 +755,237 @@ class OxiaClientTestCase(unittest.TestCase):
             self.assertEqual('a-%020d' % 4, k4)
             self.assertEqual(k4, next(gs3))
 
+            gs3.close()
             client.close()
+
+    def test_session_not_found(self):
+        """Exercises the SESSION_DOES_NOT_EXIST server status → SessionNotFound
+        client exception path. Reaches into internals to forcibly close a
+        session server-side, then does a put that reuses the stale in-memory
+        session object — the server should reject it."""
+        with OxiaContainer() as server:
+            client = oxia.Client(server.service_url(),
+                                 namespace="default",
+                                 session_timeout_ms=5_000)
+            try:
+                # Pin both puts to the same shard via partition_key, so the
+                # second put reuses the first put's session object rather than
+                # creating a fresh one on a different shard.
+                pk = "t7-partition"
+                client.put("/t7-a", 'v1', ephemeral=True, partition_key=pk)
+
+                # Grab the live session and its server-side ID.
+                sessions_by_shard = client._session_manager.sessions_by_shard
+                self.assertEqual(1, len(sessions_by_shard),
+                                 "expected exactly one session to exist")
+                shard, session = next(iter(sessions_by_shard.items()))
+                stale_session_id = session.session_id()
+
+                # Close server-side via a raw stub. The client's in-memory
+                # Session object still thinks it's alive.
+                stub = client._service_discovery.get_stub(shard)
+                stub.close_session(pb.CloseSessionRequest(
+                    shard=shard, session_id=stale_session_id))
+                self.assertFalse(session.is_closed(),
+                                 "client should still think session is alive")
+
+                # Attempting another ephemeral put on the same shard reuses
+                # the stale session and must surface as SessionNotFound.
+                with self.assertRaises(oxia.ex.SessionNotFound):
+                    client.put("/t7-b", 'v2',
+                               ephemeral=True, partition_key=pk)
+            finally:
+                client.close()
+
+    def test_delete_ephemeral_after_session_closed(self):
+        """When the client that created an ephemeral record closes, the server
+        should remove the record. A second client observing the key must see
+        KeyNotFound on get and False on delete."""
+        with OxiaContainer() as server:
+            client1 = oxia.Client(server.service_url(),
+                                  session_timeout_ms=5_000,
+                                  client_identifier="client-1")
+            k = new_key()
+            _, v = client1.put(k, 'v', ephemeral=True)
+            self.assertTrue(v.is_ephemeral())
+
+            # A second client can observe the ephemeral record while client1 is alive.
+            client2 = oxia.Client(server.service_url(),
+                                  client_identifier="client-2")
+            rk, rv, _ = client2.get(k)
+            self.assertEqual(k, rk)
+            self.assertEqual(b'v', rv)
+
+            # Closing client1 closes its session; the server removes the ephemeral.
+            client1.close()
+
+            # Give the server a moment to propagate the session-scoped delete.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                try:
+                    client2.get(k)
+                except oxia.ex.KeyNotFound:
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail(f"ephemeral key {k} was not removed within 5s of client close")
+
+            # delete() on a non-existent key returns False, not True, not raising.
+            self.assertFalse(client2.delete(k))
+            with self.assertRaises(oxia.ex.KeyNotFound):
+                client2.get(k)
+
+            client2.close()
+
+    def test_secondary_index_equal_get_returns_primary_key(self):
+        """Secondary-index lookups with the default (EQUAL) comparison must
+        return the primary key of the matched record — not the secondary key
+        the caller passed in."""
+        with OxiaContainer() as server:
+            client = oxia.Client(server.service_url())
+            try:
+                client.put('alpha', 'VALUE_007',
+                           secondary_indexes={'idx': '007'})
+
+                # EQUAL (default) — the returned key must be the primary key.
+                key, val, _ = client.get('007', use_index='idx')
+                self.assertEqual('alpha', key,
+                                 "returned key must be the primary key 'alpha', "
+                                 "not the secondary lookup value '007'")
+                self.assertEqual(b'VALUE_007', val)
+
+                # Explicit EQUAL, same expectation.
+                key, val, _ = client.get(
+                    '007', use_index='idx',
+                    comparison_type=oxia.ComparisonType.EQUAL)
+                self.assertEqual('alpha', key)
+                self.assertEqual(b'VALUE_007', val)
+            finally:
+                client.close()
+
+    def test_session_survives_beyond_timeout_window(self):
+        """A session_timeout_ms of 3000ms (the lowest value where the default
+        heartbeat cadence has a comfortable margin) must result in an
+        ephemeral record surviving past that window, proving the heartbeat
+        thread is actually keeping the session alive.
+
+        Note: 2000ms is the minimum accepted by the default heartbeat path,
+        but at exactly 2000ms the default resolves heartbeat_interval_ms to
+        1999ms — a 1ms margin that's fragile under any scheduling jitter.
+        This test deliberately uses 3000ms to exercise the mechanism without
+        depending on sub-millisecond timing."""
+        with OxiaContainer() as server:
+            client = oxia.Client(server.service_url(),
+                                 session_timeout_ms=3_000)
+            try:
+                k = new_key()
+                _, v = client.put(k, 'v', ephemeral=True)
+                self.assertTrue(v.is_ephemeral())
+
+                # Wait longer than the session timeout. The record must
+                # still be there — the heartbeat thread has been keeping
+                # the session alive.
+                time.sleep(4.5)
+
+                rk, rv, _ = client.get(k)
+                self.assertEqual(k, rk)
+                self.assertEqual(b'v', rv)
+            finally:
+                client.close()
+
+    def test_session_timeout_below_floor_rejected(self):
+        """A session_timeout_ms below the 2000ms floor must be rejected when
+        the first session is actually created (the SessionManager is lazy, so
+        the error surfaces on the first ephemeral put rather than at
+        Client construction)."""
+        with OxiaContainer() as server:
+            client = oxia.Client(server.service_url(),
+                                 session_timeout_ms=1_999)
+            try:
+                with self.assertRaises(ValueError):
+                    client.put(new_key(), 'v', ephemeral=True)
+            finally:
+                # close() must work even though we never successfully created a session
+                client.close()
+
+    def test_list_empty_range_multi_shard(self):
+        """A list() with no matching keys must return [] on a multi-shard setup
+        rather than errors — regression guard for the cross-shard merge path."""
+        with OxiaContainer(shards=5) as server:
+            client = oxia.Client(server.service_url())
+            try:
+                prefix = new_key()
+                client.put(prefix + '/a', '0')
+                client.put(prefix + '/b', '1')
+                client.put(prefix + '/c', '2')
+
+                # Range that falls entirely after the written keys.
+                self.assertEqual([], client.list(prefix + '/y', prefix + '/z'))
+
+                # Range that doesn't intersect anything the test wrote.
+                self.assertEqual(
+                    [],
+                    client.list('ZZZ_nonexistent_a', 'ZZZ_nonexistent_z'))
+            finally:
+                client.close()
+
+    def test_list_hierarchical_sort_consistency_across_shards(self):
+        """The server's list() sort order must match the client's
+        compare_with_slash, otherwise the cross-shard merge in Client.list()
+        would silently produce wrong orderings.
+
+        Uses keys chosen so that hierarchical and natural (codepoint-wise)
+        orderings differ — asserted at the end so this test can't silently
+        pass if the two were equivalent.
+
+        Note: range_scan is deliberately NOT tested here. The server uses a
+        different ordering for range_scan than for list (segment-count priority
+        rather than compare_with_slash), which means the client's cross-shard
+        heapq.merge produces incorrect output for range_scan. That is tracked
+        as a separate deferred test in tests/deferred_test.py."""
+        with OxiaContainer(shards=3) as server:
+            client = oxia.Client(server.service_url())
+            try:
+                prefix = new_key()
+                suffixes = [
+                    '/a',
+                    '/aa',
+                    '/a/b',
+                    '/a/b/c',
+                    '/aa/a',
+                    '/b',
+                    '/b/a',
+                    '/b/ab',
+                ]
+                keys = [prefix + s for s in suffixes]
+                for k in keys:
+                    client.put(k, 'v')
+
+                # Lower bound: `prefix + '/'` filters to only this test's keys
+                # (hierarchically, any other-prefix key falls outside).
+                # Upper bound: 4 '/~' segments — deep enough to hierarchically
+                # exceed every 4-segment key we wrote, since '~' is larger
+                # than every letter in our suffixes.
+                lo = prefix + '/'
+                hi = prefix + '/~/~/~/~'
+
+                expected_hier = sorted(
+                    keys, key=functools.cmp_to_key(compare_with_slash))
+
+                actual_list = client.list(lo, hi)
+                self.assertEqual(expected_hier, actual_list)
+
+                # Sanity check: the chosen key set MUST produce a different
+                # order under Python's default sorted(). If a future refactor
+                # made hierarchical = natural, this test would otherwise
+                # silently pass. Fail loudly if that happens.
+                natural = sorted(keys)
+                self.assertNotEqual(
+                    natural, expected_hier,
+                    "this test requires a key set where hierarchical and "
+                    "natural orderings differ; pick different suffixes")
+            finally:
+                client.close()
 
 
 if __name__ == '__main__':

--- a/tests/compare_test.py
+++ b/tests/compare_test.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import unittest
+from functools import cmp_to_key
+
 from oxia.internal.compare import compare_with_slash as cs
+
+
+def _natural_sign(a: str, b: str) -> int:
+    """Sign of Python's default string comparison (codepoint-wise)."""
+    return (a > b) - (a < b)
 
 
 class CompareTest(unittest.TestCase):
@@ -40,6 +47,73 @@ class CompareTest(unittest.TestCase):
         self.assertEqual(+1, cs("/aaaa/a/a", "/aaaa/bbbbbbbbbb"))
 
         self.assertEqual(+1, cs("/a/b/a/a/a", "/a/b/a/b"))
+
+    def test_edge_bytes(self):
+        # Null bytes sort below any ASCII letter inside a single segment.
+        self.assertEqual(-1, cs("\x00", "a"))
+        self.assertEqual(+1, cs("a", "\x00"))
+
+        # Null byte as a segment prefix is still compared segment-wise.
+        self.assertEqual(+1, cs("\x00/a", "/a"))
+        self.assertEqual(-1, cs("/a", "\x00/a"))
+
+        # Slash-only keys: fewer slashes sort before more slashes.
+        self.assertEqual(-1, cs("/", "//"))
+        self.assertEqual(-1, cs("//", "///"))
+        self.assertEqual(+1, cs("///", "/"))
+
+        # Empty segment between two slashes is meaningful: "a//b" != "a/b".
+        self.assertEqual(+1, cs("a//b", "a/b"))
+        self.assertEqual(-1, cs("a/b", "a//b"))
+
+        # Keys that differ only after a long common prefix must still resolve
+        # correctly (regression guard against buggy recursion bounds).
+        long_prefix = "a" * 1000
+        self.assertEqual(-1, cs(long_prefix + "/y", long_prefix + "/z"))
+        self.assertEqual(+1, cs(long_prefix + "/z", long_prefix + "/y"))
+        self.assertEqual(0, cs(long_prefix, long_prefix))
+
+    def test_hierarchical_vs_natural(self):
+        """Oxia's hierarchical sort deliberately differs from Python's codepoint-wise
+        compare. Each case here is a regression guard that (1) the hierarchical
+        rule gives the expected sign AND (2) natural ordering gives the opposite
+        sign — so the test is proven to be exercising the divergence, not
+        accidentally passing because the two orderings happen to agree."""
+        divergent_cases = [
+            # (a, b, expected hierarchical sign)
+            ("a", "/", -1),                           # no-slash key sorts before slash key
+            ("abcd", "a/c", -1),                      # same: no-slash < slash, even when 'b' > '/'
+            ("b", "/", -1),
+            ("/aaaa/a/a", "/bbbbbbbbbb", +1),         # deeper path with 'a' beats shallower 'b'
+            ("/aaaa/a/a", "/aaaa/bbbbbbbbbb", +1),    # second segment: deeper 'a' beats shallower 'b'
+            ("ab/c", "b", +1),                        # slash key sorts after no-slash key
+        ]
+        for a, b, expected_hier in divergent_cases:
+            with self.subTest(a=a, b=b):
+                hier = cs(a, b)
+                self.assertEqual(expected_hier, hier,
+                                 f"hierarchical cs({a!r}, {b!r}) = {hier}, expected {expected_hier}")
+                nat = _natural_sign(a, b)
+                self.assertNotEqual(hier, nat,
+                                    f"this case is supposed to diverge from natural ordering, but "
+                                    f"cs({a!r},{b!r})={hier} matches natural sign {nat}")
+
+    def test_sorted_list(self):
+        """Using `compare_with_slash` as a sort key must produce the correct
+        hierarchical ordering over a list. The chosen keys intentionally produce
+        a different order under Python's default `sorted()` — asserted at the
+        end so a future refactor that makes cs() natural-equivalent would fail
+        loudly here rather than silently pass."""
+        keys = ["a", "/", "aa", "a/b", "ab", "ab/c", "b", "/a"]
+
+        hierarchical = sorted(keys, key=cmp_to_key(cs))
+        expected = ["a", "aa", "ab", "b", "/", "/a", "a/b", "ab/c"]
+        self.assertEqual(expected, hierarchical)
+
+        natural = sorted(keys)
+        self.assertNotEqual(natural, hierarchical,
+                            "natural and hierarchical orderings must differ for this key set; "
+                            "otherwise the test is not exercising the hierarchical rule")
 
 
 if __name__ == '__main__':

--- a/tests/sessions_test.py
+++ b/tests/sessions_test.py
@@ -18,6 +18,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from oxia.client import _get_version
+from oxia.internal.proto.io.streamnative.oxia import proto as pb
 from oxia.internal.sessions import (
     Session,
     SessionManager,
@@ -265,3 +267,37 @@ def test_session_manager_close_shuts_down_all_sessions():
     assert s2.is_closed()
     assert {entry[0] for entry in stub.closed} == {3, 5}
     assert manager.sessions_by_shard == {}
+
+
+def _make_pb_version(**overrides):
+    """Build a synthetic pb.Version for unit-testing _get_version()."""
+    base = dict(
+        version_id=42,
+        modifications_count=3,
+        created_timestamp=1_000,
+        modified_timestamp=2_000,
+    )
+    base.update(overrides)
+    return pb.Version(**base)
+
+
+def test_get_version_non_ephemeral_record_has_no_session():
+    v = _get_version(_make_pb_version())
+    assert v.is_ephemeral() is False
+    assert v.session_id() is None
+    assert v.client_identity() is None
+
+
+def test_get_version_ephemeral_record_with_nonzero_session_id():
+    v = _get_version(_make_pb_version(session_id=7, client_identity="alice"))
+    assert v.is_ephemeral() is True
+    assert v.session_id() == 7
+    assert v.client_identity() == "alice"
+
+
+def test_get_version_ephemeral_record_with_session_id_zero():
+    """Regression guard for is_ephemeral(): must check `is not None`, not
+    truthiness. A session ID of 0 is still a valid ephemeral session."""
+    v = _get_version(_make_pb_version(session_id=0))
+    assert v.is_ephemeral() is True
+    assert v.session_id() == 0


### PR DESCRIPTION
## Summary

- **compare_test.py**: edge-byte cases (null bytes, slash-only keys, empty segments, long common prefixes), explicit hierarchical-vs-natural sort divergence with assertion that natural ordering gives the opposite sign, and sorted-list transitivity test
- **sessions_test.py**: `_get_version` unit tests for ephemeral/non-ephemeral records, including a `session_id=0` regression guard against a truthy-check refactor
- **client_test.py**: 8 new integration tests + 2 strengthened existing tests:
  - `SessionNotFound` via forcibly-closed server-side session
  - Delete ephemeral after session close (cross-client observation)
  - Secondary-index EQUAL echo-back (the one comparison type the existing test missed)
  - Session timeout boundary cases (heartbeat survival + below-floor rejection)
  - Empty-range `list()` on multi-shard setup
  - Cross-shard hierarchical sort consistency for `list()`
  - Multi-shard assertion in `test_floor_ceiling_get`
  - Enabled previously commented-out `test_sequence_updates` block

## Test plan

- [x] `uv run pytest tests/compare_test.py -v` — 4 passed
- [x] `uv run pytest tests/sessions_test.py -v` — 17 passed
- [x] `uv run pytest tests/client_test.py -v` — 23 passed
- [x] `uv run pytest tests/ -v` — 43 passed, 0 failed