### PR TITLE
Test against Python 3.10 through 3.14

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -25,6 +25,10 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Checkout repository
@@ -33,14 +37,15 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
 
-    - name: Install Python
-      run: uv python install 3.13
+    - name: Install Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
 
     - name: Build distribution packages
-      run: uv build
+      run: uv build -p ${{ matrix.python-version }}
 
     - name: Run tests
-      run: uv run pytest
+      run: uv run -p ${{ matrix.python-version }} pytest
 
     - name: Verify documentation
-      run: uv run pydoctor --config pydoctor.ini
+      if: matrix.python-version == '3.13'
+      run: uv run -p ${{ matrix.python-version }} pydoctor --config pydoctor.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 dynamic = ["version"]
 
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 
 dependencies = [
     "betterproto2-compiler",

--- a/src/oxia/internal/notifications.py
+++ b/src/oxia/internal/notifications.py
@@ -18,6 +18,8 @@ import threading, queue, logging
 from oxia.internal.proto.io.streamnative.oxia import proto as pb
 from oxia.defs import Notification, NotificationType
 
+_SHUTDOWN = object()
+
 class Notifications:
     def __init__(self, service_discovery : ServiceDiscovery):
         self._lock = threading.Lock()
@@ -37,7 +39,7 @@ class Notifications:
 
             for thread in self._threads:
                 thread.join()
-        self._notifications.shutdown()
+        self._notifications.put(_SHUTDOWN)
 
 
     def _get_notifications_with_retries(self):
@@ -110,6 +112,8 @@ class Notifications:
 
     def __next__(self):
         i = self._notifications.get()
+        if i is _SHUTDOWN:
+            raise StopIteration
         self._notifications.task_done()
         return i
 

--- a/src/oxia/internal/sequence_updates.py
+++ b/src/oxia/internal/sequence_updates.py
@@ -19,6 +19,9 @@ from oxia.internal.service_discovery import ServiceDiscovery
 from oxia.internal.proto.io.streamnative.oxia import proto as pb
 
 
+_SHUTDOWN = object()
+
+
 class SequenceUpdatesImpl:
     def __init__(self, service_discovery: ServiceDiscovery, prefix_key: str, partition_key: str, is_client_closed):
         self._service_discovery = service_discovery
@@ -57,12 +60,11 @@ class SequenceUpdatesImpl:
         return self
 
     def __next__(self):
-        try:
-            i = self._queue.get()
-            self._queue.task_done()
-            return i
-        except queue.ShutDown:
+        i = self._queue.get()
+        if i is _SHUTDOWN:
             raise StopIteration
+        self._queue.task_done()
+        return i
 
     def close(self):
         with self._lock:
@@ -70,6 +72,6 @@ class SequenceUpdatesImpl:
             if self._stream:
                 self._stream.cancel()
 
-            self._queue.shutdown()
+            self._queue.put(_SHUTDOWN)
             if self._thread != threading.current_thread():
                 self._thread.join()

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import queue
 import unittest
 
 import oxia
@@ -122,7 +121,7 @@ class OxiaClientTestCase(unittest.TestCase):
             self.assertEqual(s4.version_id(), n.version_id())
 
             notifications.close()
-            with self.assertRaises(queue.ShutDown):
+            with self.assertRaises(StopIteration):
                 next(notifications)
 
             notifications2.close()


### PR DESCRIPTION
## Summary

- Lower `requires-python` from `>=3.13` to `>=3.10`
- Replace `Queue.shutdown()` / `queue.ShutDown` (added in 3.13) with a sentinel pattern that works on all supported versions
- Add CI matrix: Python 3.10, 3.11, 3.12, 3.13, 3.14 with `fail-fast: false`
- Run `pydoctor` only on 3.13 to avoid version-specific doc tool issues

## Test plan

- [x] `uv run pytest tests/` passes locally on 3.13
- [ ] CI matrix runs green on all 5 Python versions