### PR TITLE
Fix SequenceUpdatesImpl to inherit from SequenceUpdates ABC

### DIFF
--- a/src/oxia/__init__.py
+++ b/src/oxia/__init__.py
@@ -27,11 +27,11 @@ from oxia.client import (
     Version,
     EXPECTED_RECORD_DOES_NOT_EXIST,
     ComparisonType,
-    SequenceUpdates
 )
 from oxia.defs import (
     NotificationType,
     Notification,
+    SequenceUpdates,
 )
 
 __all__ = [

--- a/src/oxia/client.py
+++ b/src/oxia/client.py
@@ -22,8 +22,8 @@ from oxia.internal.sessions import SessionManager
 from oxia.internal.service_discovery import ServiceDiscovery
 from oxia.internal.proto.io.streamnative.oxia import proto as pb
 import oxia.ex
+import oxia.defs
 
-from abc import ABC
 import datetime
 import enum
 from typing import Iterator
@@ -134,17 +134,6 @@ class Version:
 
 EXPECTED_RECORD_DOES_NOT_EXIST = -1
 """When doing a `put()`, this value can be used to indicate that the record should not exist."""
-
-class SequenceUpdates(Iterator[str], ABC):
-    """
-    Represents an iterable sequence of key updates that can be closed when the caller is done.
-    """
-
-    def close(self):
-        """
-        Close the iterator and release any resources.
-        """
-        pass
 
 
 class Client:
@@ -438,7 +427,7 @@ class Client:
             for x in res.records:
                 yield x.key, x.value, _get_version(x.version)
 
-    def get_sequence_updates(self, prefix_key: str, partition_key: str = None) -> SequenceUpdates:
+    def get_sequence_updates(self, prefix_key: str, partition_key: str = None) -> oxia.defs.SequenceUpdates:
         """
         Subscribe to the updates happening on a sequential key.
 

--- a/src/oxia/defs.py
+++ b/src/oxia/defs.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import ABC
 from enum import Enum
+from typing import Iterator
 
 class NotificationType(Enum):
     """NotificationType represents the type of the notification event."""
@@ -45,4 +47,16 @@ class Notification:
 
     def __str__(self):
         return f"Notification(key: {self.key()}, type: {self.notification_type()}, version_id: {self.version_id()}, key_range_end: {self.key_range_end()})"
+
+
+class SequenceUpdates(Iterator[str], ABC):
+    """
+    Represents an iterable sequence of key updates that can be closed when the caller is done.
+    """
+
+    def close(self):
+        """
+        Close the iterator and release any resources.
+        """
+        pass
 

--- a/src/oxia/internal/sequence_updates.py
+++ b/src/oxia/internal/sequence_updates.py
@@ -15,11 +15,12 @@
 import threading, queue
 import grpc
 
+from oxia.defs import SequenceUpdates
 from oxia.internal.service_discovery import ServiceDiscovery
 from oxia.internal.proto.io.streamnative.oxia import proto as pb
 
 
-class SequenceUpdatesImpl:
+class SequenceUpdatesImpl(SequenceUpdates):
     def __init__(self, service_discovery: ServiceDiscovery, prefix_key: str, partition_key: str, is_client_closed):
         self._service_discovery = service_discovery
         self._queue = queue.Queue(10)

--- a/tests/sequence_updates_test.py
+++ b/tests/sequence_updates_test.py
@@ -1,0 +1,27 @@
+# Copyright 2025 The Oxia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the SequenceUpdates type contract."""
+
+from oxia.defs import SequenceUpdates
+from oxia.internal.sequence_updates import SequenceUpdatesImpl
+
+
+def test_sequence_updates_impl_is_a_sequence_updates():
+    """SequenceUpdatesImpl must be a subclass of the SequenceUpdates ABC.
+
+    Currently FAILS because SequenceUpdatesImpl is an unrelated class
+    that doesn't inherit from SequenceUpdates."""
+    assert issubclass(SequenceUpdatesImpl, SequenceUpdates), \
+        "SequenceUpdatesImpl should inherit from SequenceUpdates"


### PR DESCRIPTION
SequenceUpdatesImpl was an unrelated class that didn't inherit from the SequenceUpdates ABC, breaking the type contract.

Moved SequenceUpdates ABC from client.py to defs.py (avoids circular import) and made SequenceUpdatesImpl inherit from it.