### PR TITLE
Fix ServiceDiscovery init barrier timeout error

### DIFF
--- a/src/oxia/internal/service_discovery.py
+++ b/src/oxia/internal/service_discovery.py
@@ -44,7 +44,8 @@ class Shard:
 
 class ServiceDiscovery(object):
 
-    def __init__(self, service_address, connection_pool, namespace):
+    def __init__(self, service_address, connection_pool, namespace,
+                 init_timeout=30):
         self._assignments = {}
         self._service_address = service_address
         self._connection_pool = connection_pool
@@ -57,7 +58,13 @@ class ServiceDiscovery(object):
 
         # Wait until we have the first assignment map
         self._init_barrier = threading.Barrier(2)
-        self._init_barrier.wait(30)
+        try:
+            self._init_barrier.wait(init_timeout)
+        except threading.BrokenBarrierError:
+            raise RuntimeError(
+                f"Timed out after {init_timeout}s waiting for initial shard "
+                f"assignments from {service_address}"
+            ) from None
 
     def get_assignments(self):
         stub = self._connection_pool.get(self._service_address)

--- a/tests/service_discovery_test.py
+++ b/tests/service_discovery_test.py
@@ -1,0 +1,42 @@
+# Copyright 2025 The Oxia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for oxia.internal.service_discovery.ServiceDiscovery."""
+
+import pytest
+
+from oxia.internal.service_discovery import ServiceDiscovery
+
+
+class FailingStub:
+    """A stub whose get_shard_assignments always raises."""
+
+    def get_shard_assignments(self, request):
+        raise ConnectionError("simulated connection failure")
+
+
+class FailingConnectionPool:
+    """Returns a FailingStub for any address."""
+
+    def get(self, address):
+        return FailingStub()
+
+
+def test_init_raises_on_connection_failure():
+    """When the initial shard-assignments stream cannot be established
+    within the timeout, the constructor must raise a clear RuntimeError
+    rather than propagating a BrokenBarrierError."""
+    with pytest.raises(RuntimeError, match="Timed out.*shard assignments"):
+        ServiceDiscovery("localhost:99999", FailingConnectionPool(), "default",
+                         init_timeout=1)


### PR DESCRIPTION
When the initial shard-assignments stream could not be established within the timeout, the constructor raised a confusing BrokenBarrierError with no context.

Now catches the barrier timeout and raises RuntimeError naming the service address and timeout duration. The timeout is also configurable via init_timeout parameter.