### PR TITLE
Fix put() value type handling and KeyNotFound consistency

### DIFF
--- a/src/oxia/client.py
+++ b/src/oxia/client.py
@@ -28,6 +28,17 @@ import datetime
 import enum
 from typing import Iterator
 
+def _coerce_value(value) -> bytes:
+    """Coerce a put() value to bytes."""
+    if isinstance(value, str):
+        return value.encode('utf-8')
+    elif isinstance(value, bytes):
+        return value
+    else:
+        raise TypeError(
+            f"value must be str or bytes, got {type(value).__name__}")
+
+
 def _check_status(status: pb.Status):
     if status == pb.Status.OK:
         pass
@@ -210,8 +221,7 @@ class Client:
             if expected_version_id is not None:
                 raise oxia.ex.InvalidOptions("sequence_keys_deltas cannot be used with expected_version_id")
 
-        if type(value) is str:
-            value = bytes(str(value), encoding='utf-8')
+        value = _coerce_value(value)
 
         pr = pb.PutRequest(key=key, value=value,
                            partition_key=partition_key,
@@ -326,7 +336,7 @@ class Client:
                     results.append((k, val, version))
                 except oxia.ex.KeyNotFound:
                     pass
-            if not results: raise oxia.ex.KeyNotFound
+            if not results: raise oxia.ex.KeyNotFound()
             results.sort(key=functools.cmp_to_key(compare_tuple_with_slash))
 
             if comparison_type == ComparisonType.EQUAL or \

--- a/tests/client_unit_test.py
+++ b/tests/client_unit_test.py
@@ -1,0 +1,45 @@
+# Copyright 2025 The Oxia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for client-level value coercion (bug #7)."""
+
+import pytest
+
+
+def test_coerce_value_str():
+    """str values should be encoded to UTF-8 bytes."""
+    from oxia.client import _coerce_value
+    assert _coerce_value("hello") == b"hello"
+
+
+def test_coerce_value_bytes():
+    """bytes values should pass through unchanged."""
+    from oxia.client import _coerce_value
+    assert _coerce_value(b"hello") == b"hello"
+
+
+def test_coerce_value_rejects_int():
+    """Non-str/non-bytes values must raise TypeError.
+
+    Currently FAILS because put() passes them through to protobuf
+    where they error deep in serialization."""
+    from oxia.client import _coerce_value
+    with pytest.raises(TypeError, match="str or bytes"):
+        _coerce_value(42)
+
+
+def test_coerce_value_rejects_none():
+    from oxia.client import _coerce_value
+    with pytest.raises(TypeError, match="str or bytes"):
+        _coerce_value(None)


### PR DESCRIPTION
**Bug #7**: put() used \`type(value) is str\` (rejects str subclasses) and \`bytes(str(value), ...)\` (redundant). Non-str/non-bytes values errored deep in protobuf serialization.

Extracted \`_coerce_value()\`: isinstance checks, clear TypeError for invalid types.

**Bug #9**: \`raise oxia.ex.KeyNotFound\` (class) → \`raise oxia.ex.KeyNotFound()\` (instance) for consistency.