### PR TITLE
Fix return type annotations to use proper tuple[] syntax

### DIFF
--- a/src/oxia/client.py
+++ b/src/oxia/client.py
@@ -181,7 +181,7 @@ class Client:
             ephemeral: bool = False,
             sequence_keys_deltas: list[int] = None,
             secondary_indexes: dict[str, str] = None,
-            ) -> (str, Version):
+            ) -> tuple[str, Version]:
         """
         Associates a value with a key
 
@@ -302,7 +302,7 @@ class Client:
             comparison_type: ComparisonType = ComparisonType.EQUAL,
             include_value: bool = True,
             use_index: str = None,
-            ) -> (str, str, Version):
+            ) -> tuple[str, bytes, Version]:
         """
         Returns the value associated with the specified key.
 
@@ -348,7 +348,7 @@ class Client:
                           key: str,
                           comparison_type: ComparisonType,
                           include_value: bool,
-                          use_index: str) -> (str, str, Version):
+                          use_index: str) -> tuple[str, bytes, Version]:
         gr = pb.GetRequest(key=key,
                            comparison_type=comparison_type,
                            include_value=include_value,
@@ -404,7 +404,7 @@ class Client:
                    max_key_exclusive: str,
                    partition_key: str = None,
                    use_index: str = None,
-                   ) -> Iterator[tuple[str, str, Version]]:
+                   ) -> Iterator[tuple[str, bytes, Version]]:
         """
         perform a scan for existing records with any keys within the specified range.
 
@@ -429,7 +429,7 @@ class Client:
 
     @staticmethod
     def _range_scan_single_shard(shard, stub, min_key_inclusive: str, max_key_exclusive: str, use_index: str) \
-                            -> Iterator[tuple[str, str, Version]]:
+                            -> Iterator[tuple[str, bytes, Version]]:
         it = stub.range_scan(pb.RangeScanRequest(shard=shard,
                             start_inclusive=min_key_inclusive,
                             end_exclusive=max_key_exclusive,

--- a/src/oxia/internal/service_discovery.py
+++ b/src/oxia/internal/service_discovery.py
@@ -113,7 +113,7 @@ class ServiceDiscovery(object):
                     return self._connection_pool.get(s.leader)
         raise Exception(f'No stub found for shard {shard}')
 
-    def get_leader(self, key: str, partition_key: str) -> (int, pb.OxiaClientStub):
+    def get_leader(self, key: str, partition_key: str) -> tuple[int, pb.OxiaClientStub]:
         hashing_key = partition_key if partition_key else key
         s = self.get_shard(hashing_key)
         return s.shard, self._connection_pool.get(s.leader)


### PR DESCRIPTION
Parenthesized tuples like `-> (str, Version)` are not valid type hints. Fixed to `-> tuple[str, Version]`. Also corrected value type from `str` to `bytes` in get/range_scan return types.