### PR TITLE
Make Client a context manager

### DIFF
--- a/src/oxia/client.py
+++ b/src/oxia/client.py
@@ -469,3 +469,10 @@ class Client:
         self._session_manager.close()
         self._connections.close()
         self._service_discovery.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False


### PR DESCRIPTION
Adds `__enter__`/`__exit__` so the client can be used with:

```python
with oxia.Client('localhost:6648') as client:
    client.put('key', 'value')
```

`close()` is called automatically when the block exits. Matches the Java SDK's `AutoCloseable` pattern.