### PR TITLE
Fix authors field to match copyright headers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 name = "oxia"
 description = "Oxia client for Python"
 authors = [
-    { name = "StreamNative"}
+    { name = "The Oxia Authors"}
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
pyproject.toml said "StreamNative" but every source file header says "Copyright 2025 The Oxia Authors".