### PR TITLE
Improve README and CONTRIBUTING documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,28 +22,54 @@ If you have questions regarding Oxia, feel free to start a new discussion: https
    useful to help troubleshoot it (e.g. OS environment, configuration,
    etc...). Also state the current behavior vs. the expected behavior.
 1. If you'd like to see a feature or an enhancement please create a new [idea
-   discussion](https://github.com/oxia-db/oxia/discussions/new?category=ideas) with 
+   discussion](https://github.com/oxia-db/oxia/discussions/new?category=ideas) with
    a clear title and description of what the feature is and why it would be
    beneficial to the project and its users.
 
+## Development setup
+
+Requirements:
+
+* Python 3.10+
+* [uv](https://docs.astral.sh/uv/) (package manager)
+* Docker (for integration tests via testcontainers)
+
+Install dependencies:
+
+```bash
+uv sync
+```
+
+## Running tests
+
+```bash
+# All tests (unit + integration — requires Docker)
+uv run pytest
+
+# Unit tests only (no Docker needed)
+uv run pytest tests/compare_test.py tests/sessions_test.py
+
+# With coverage
+uv run pytest --cov --cov-report=term-missing
+```
+
+## Regenerating protobuf bindings
+
+If the Oxia proto definitions change:
+
+```bash
+./gen-proto.sh
+```
+
 ## Submitting changes
 
-<!--
-1. CLA: Upon submitting a Pull Request (PR), contributors will be prompted to
-   sign a CLA. Please sign the CLA :slightly_smiling_face:
-   -->
-1. Tests: If you are submitting code, please ensure you have adequate tests
-   for the feature. Tests can be run via `make test`.
-1. Since this is golang project, ensure the new code is properly formatted to
-   ensure code consistency. Run `make lint`.
-
-### Quick steps to contribute
-
 1. Fork the project.
-1. Download your fork to your PC (`git clone https://github.com/your_username/oxia && cd oxia`)
+1. Clone your fork (`git clone https://github.com/your_username/oxia-client-python && cd oxia-client-python`)
 1. Create your feature branch (`git checkout -b my-new-feature`)
-1. Make changes and run tests (`make test`)
-1. Add them to staging (`git add .`)
-1. Commit your changes (`git commit -m 'Add some feature'`)
+1. Make changes and run tests (`uv run pytest`)
+1. Commit your changes with DCO sign-off (`git commit -s -m 'Add some feature'`)
 1. Push to the branch (`git push origin my-new-feature`)
-1. Create new pull request
+1. Create a new pull request
+
+**Note:** All commits must include a
+[DCO sign-off](https://developercertificate.org/) (`git commit -s`).

--- a/README.md
+++ b/README.md
@@ -1,27 +1,73 @@
+# Oxia Python Client SDK
 
-<h2 align="center">Oxia Client SDK for Python</h1>
-a robust, scalable metadata store and coordination system designed for large-scale distributed systems, with built-in support for stream index storage to optimize real-time data management.
+[![CI](https://github.com/oxia-db/oxia-client-python/actions/workflows/run-tests.yaml/badge.svg)](https://github.com/oxia-db/oxia-client-python/actions/workflows/run-tests.yaml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-white.svg)](https://github.com/oxia-db/oxia-client-python/blob/main/LICENSE)
+
+Python client for [Oxia](https://oxia-db.github.io/), a scalable metadata store and coordination
+system for large-scale distributed systems.
 
 <p align="center">
-  <a href="https://oxia-db.github.io/docs/getting-started">Getting Started </a> | <a href="https://oxia-db.github.io/">Documentation</a>
+  <a href="https://oxia-db.github.io/docs/getting-started">Getting Started</a> |
+  <a href="https://oxia-db.github.io/">Documentation</a> |
+  <a href="https://github.com/oxia-db/oxia/discussions/new/choose">Discussion</a>
 </p>
 
-<p align="center">
-  <a href="https://github.com/oxia-db/oxia-client-python/releases"><img src="https://img.shields.io/github/v/release/oxia-db/oxia" alt="Latest Release"></a>
-  <a href="https://github.com/oxia-db/oxia-client-python/actions/workflows/run-tests.yaml/badge.svg"><img src="https://github.com/oxia-db/oxia-client-python/actions/workflows/run-tests.yaml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/oxia-db/oxia-client-python/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-white.svg" alt="License"></a>
-  <a href="https://github.com/oxia-db/oxia-client-python/discussions/new/choose"><img src="https://img.shields.io/badge/Github-Discussion-blue.svg?logo=refinedgithub" alt="Github Discussion"></a>
-</p>
+## Requirements
 
-<br><br><br>
+* Python 3.10+
 
-### Contributing to Oxia
+## Installation
 
-Please 🌟 star the project if you like it. 
+```bash
+pip install oxia
+```
 
-Feel free to open an [issue](https://github.com/oxia-db/oxia-client-python/issues/new) or start a [discussion](https://github.com/oxia-db/oxia/discussions/new/choose). You can also follow the development [guide]() to contribute and build on it.
+## Quick start
 
-### License
+```python
+import oxia
+
+with oxia.Client('localhost:6648') as client:
+    # Put a value
+    key, version = client.put('/my-key', b'my-value')
+
+    # Get it back
+    key, value, version = client.get('/my-key')
+
+    # Conditional put (only if version matches)
+    key, version = client.put('/my-key', b'new-value',
+                              expected_version_id=version.version_id())
+
+    # List keys in a range
+    keys = client.list('/my-', '/my-~')
+
+    # Delete
+    client.delete('/my-key')
+```
+
+## Features
+
+- **CRUD operations**: `put`, `get`, `delete`, `delete_range`
+- **Range queries**: `list` (keys only), `range_scan` (keys + values)
+- **Conditional writes**: version-based optimistic concurrency via `expected_version_id`
+- **Ephemeral records**: session-scoped keys that are removed when the client disconnects
+- **Notifications**: subscribe to real-time change events
+- **Sequential keys**: server-assigned monotonic key suffixes
+- **Secondary indexes**: additional lookup keys on records
+- **Partition routing**: co-locate related records on the same shard via `partition_key`
+- **Floor/Ceiling/Lower/Higher lookups**: nearest-key queries
+
+For the full API reference, see the [documentation](https://oxia-db.github.io/oxia-client-python/latest/).
+
+## Contributing
+
+Please star the project if you like it!
+
+Feel free to open an [issue](https://github.com/oxia-db/oxia-client-python/issues/new)
+or start a [discussion](https://github.com/oxia-db/oxia/discussions/new/choose).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+
+## License
 
 Copyright 2025 The Oxia Authors
 

--- a/src/oxia/__init__.py
+++ b/src/oxia/__init__.py
@@ -17,9 +17,9 @@ Oxia Client SDK for Python.
 
 Usage example::
 
-    client = oxia.Client('oxia://localhost:6648', namespace='default')
-    key, version = client.put('my-key', 'my-value')
-    key, value, version = client.get('my-key')
+    with oxia.Client('localhost:6648') as client:
+        key, version = client.put('/my-key', b'my-value')
+        key, value, version = client.get('/my-key')
 """
 
 from oxia.client import (


### PR DESCRIPTION
## Summary

**README.md** — rewritten:
- Fixed h2/h1 tag mismatch
- Added install instructions (`pip install oxia`)
- Added quick-start code snippet showing put/get/list/delete with context manager
- Added feature list covering all supported operations
- Fixed CI badge to point to the Python client repo (was pointing to the server)
- Added Python 3.10+ requirement
- Removed broken empty `[guide]()` link
- Rewrote subtitle to describe the client, not Oxia itself

**CONTRIBUTING.md** — rewritten for Python:
- Replaced "golang project" / `make test` / `make lint` with `uv run pytest`
- Fixed clone URL from `oxia` to `oxia-client-python`
- Added development setup section (uv, Docker for testcontainers, proto regen)
- Documented DCO sign-off requirement

**`__init__.py`** — fixed usage example:
- Removed `oxia://` scheme prefix (not used by the client)
- Added context manager pattern
- Changed value to `bytes` literal