### PR TITLE
Use deploy key instead of personal token for docs publishing

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -22,12 +22,16 @@ on:
       - main
 
 permissions:
-  contents: write  # Needed to push to gh-pages branch
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-docs:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
@@ -62,7 +66,7 @@ jobs:
     - name: Update latest symlink
       uses: peaceiris/actions-gh-pages@v4
       with:
-        personal_token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
+        deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}
         external_repository: oxia-db/oxia-db.github.io
         publish_branch: main
         publish_dir: ./docs/api


### PR DESCRIPTION
The `PAGES_DEPLOY_TOKEN` personal access token expired, causing the docs publish workflow to fail with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
```

Switched to `deploy_key: PAGES_DEPLOY_KEY` matching the approach used by `oxia-client-java`. Deploy keys don't expire.

Also: downgraded permissions to `contents: read` and added concurrency control.