### PR TITLE
Improve PyPI package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@
 
 [project]
 name = "oxia"
-description = "Oxia client for Python"
+description = "Python client for Oxia, a scalable metadata store and coordination system"
+readme = "README.md"
+license = {text = "Apache-2.0"}
 authors = [
     { name = "The Oxia Authors"}
 ]
@@ -22,11 +24,31 @@ dynamic = ["version"]
 
 requires-python = ">=3.10"
 
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Database",
+    "Topic :: System :: Distributed Computing",
+]
+
 dependencies = [
     "betterproto2-compiler",
     "grpcio",
     "xxhash",
 ]
+
+[project.urls]
+Homepage = "https://oxia-db.github.io/"
+Documentation = "https://oxia-db.github.io/oxia-client-python/latest/"
+Repository = "https://github.com/oxia-db/oxia-client-python"
+Issues = "https://github.com/oxia-db/oxia-client-python/issues"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
The PyPI page at https://pypi.org/project/oxia/ was nearly empty — just the one-line description with no README, no links, no classifiers.

Changes:
- **`readme = "README.md"`** — the full README now renders as the PyPI long description
- **`license`** — Apache-2.0
- **`classifiers`** — Python 3.10–3.14, Beta status, Database/Distributed Computing topics
- **`[project.urls]`** — Homepage, Documentation, Repository, Issues
- **`description`** — improved one-liner

Also fixed TOML section ordering: `dependencies` was after `[project.urls]`, causing hatchling to parse it as a URL entry.