### PR TITLE
Add request_timeout_ms configuration

### DIFF
--- a/src/oxia/client.py
+++ b/src/oxia/client.py
@@ -151,6 +151,7 @@ class Client:
                  namespace: str = "default",
                  session_timeout_ms: int = 30_000,
                  client_identifier: str = None,
+                 request_timeout_ms: int = 30_000,
                  ):
         """Create a new Oxia client.
 
@@ -160,9 +161,15 @@ class Client:
             ephemeral records. Default is 30 000 ms.
         @param client_identifier: Optional client identity string. If
             ``None``, a random UUID is generated.
+        @param request_timeout_ms: Deadline for each unary/finite RPC
+            (``put``, ``delete``, ``get``, ``list``, ``range_scan``,
+            session management). Long-lived streams (notifications,
+            sequence updates, shard assignments) are not bounded.
+            Default is 30 000 ms. A ``grpc.RpcError`` with
+            ``StatusCode.DEADLINE_EXCEEDED`` is raised on timeout.
         """
         self._closed = False
-        self._connections = ConnectionPool()
+        self._connections = ConnectionPool(request_timeout_ms=request_timeout_ms)
         self._service_discovery = ServiceDiscovery(service_address, self._connections, namespace)
         self._session_manager = SessionManager(self._service_discovery, session_timeout_ms, client_identifier)
 

--- a/src/oxia/internal/connection_pool.py
+++ b/src/oxia/internal/connection_pool.py
@@ -13,22 +13,30 @@
 # limitations under the License.
 
 import threading
+from typing import Optional
 
 import grpc
+from oxia.internal.interceptors import RequestTimeoutInterceptor
 from oxia.internal.proto.io.streamnative.oxia.proto import OxiaClientStub
 
 
 class ConnectionPool:
 
-    def __init__(self):
+    def __init__(self, request_timeout_ms: Optional[int] = None):
         self._lock = threading.Lock()
         self.connections = {}
+        self._interceptors = []
+        if request_timeout_ms is not None:
+            self._interceptors.append(
+                RequestTimeoutInterceptor(request_timeout_ms / 1000.0))
 
     def get(self, address) -> OxiaClientStub:
         with self._lock:
             x = self.connections.get(address)
             if x is None:
                 channel = grpc.insecure_channel(address)
+                if self._interceptors:
+                    channel = grpc.intercept_channel(channel, *self._interceptors)
                 stub = OxiaClientStub(channel)
                 x = (channel, stub)
                 self.connections[address] = x

--- a/src/oxia/internal/interceptors.py
+++ b/src/oxia/internal/interceptors.py
@@ -1,0 +1,52 @@
+# Copyright 2025 The Oxia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""gRPC client interceptors used by the Oxia client."""
+
+import grpc
+
+# Server streaming RPCs that are long-lived and should NOT carry a
+# request timeout (they stay open for the lifetime of the client
+# subscription).
+_LONG_LIVED_STREAMS = frozenset({
+    "/io.streamnative.oxia.proto.OxiaClient/GetShardAssignments",
+    "/io.streamnative.oxia.proto.OxiaClient/GetNotifications",
+    "/io.streamnative.oxia.proto.OxiaClient/GetSequenceUpdates",
+    "/io.streamnative.oxia.proto.OxiaClient/RangeScan",
+})
+
+
+class RequestTimeoutInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+):
+    """Apply a default per-call deadline to every RPC that does not
+    already carry one, except for the long-lived server-streaming RPCs
+    listed in ``_LONG_LIVED_STREAMS``."""
+
+    def __init__(self, timeout_s: float):
+        self._timeout_s = timeout_s
+
+    def _with_timeout(self, client_call_details):
+        if client_call_details.method in _LONG_LIVED_STREAMS:
+            return client_call_details
+        if client_call_details.timeout is not None:
+            return client_call_details
+        return client_call_details._replace(timeout=self._timeout_s)
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        return continuation(self._with_timeout(client_call_details), request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        return continuation(self._with_timeout(client_call_details), request)

--- a/tests/request_timeout_test.py
+++ b/tests/request_timeout_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025 The Oxia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the RequestTimeoutInterceptor."""
+
+from types import SimpleNamespace
+
+from oxia.internal.interceptors import RequestTimeoutInterceptor, _LONG_LIVED_STREAMS
+
+
+def _make_details(method, timeout=None):
+    """Minimal stand-in for grpc.ClientCallDetails."""
+    return SimpleNamespace(
+        method=method,
+        timeout=timeout,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
+    )
+
+
+# SimpleNamespace doesn't have _replace — create a real namedtuple-backed thing
+from collections import namedtuple
+
+CallDetails = namedtuple("CallDetails",
+                         ["method", "timeout", "metadata", "credentials",
+                          "wait_for_ready", "compression"])
+
+
+def _details(method, timeout=None):
+    return CallDetails(method, timeout, None, None, None, None)
+
+
+class _Recorder:
+    """Captures the CallDetails passed to a continuation."""
+    def __init__(self):
+        self.last_details = None
+
+    def __call__(self, details, request):
+        self.last_details = details
+        return None
+
+
+def test_interceptor_adds_timeout_to_unary_unary():
+    interceptor = RequestTimeoutInterceptor(timeout_s=5.0)
+    rec = _Recorder()
+    details = _details("/io.streamnative.oxia.proto.OxiaClient/Write")
+
+    interceptor.intercept_unary_unary(rec, details, object())
+    assert rec.last_details.timeout == 5.0
+
+
+def test_interceptor_respects_explicit_timeout():
+    """If a caller already set a timeout, the interceptor must not overwrite it."""
+    interceptor = RequestTimeoutInterceptor(timeout_s=5.0)
+    rec = _Recorder()
+    details = _details("/io.streamnative.oxia.proto.OxiaClient/Write", timeout=1.0)
+
+    interceptor.intercept_unary_unary(rec, details, object())
+    assert rec.last_details.timeout == 1.0
+
+
+def test_interceptor_skips_long_lived_streams():
+    """Long-lived server-streaming RPCs must not carry a timeout."""
+    interceptor = RequestTimeoutInterceptor(timeout_s=5.0)
+    for method in _LONG_LIVED_STREAMS:
+        rec = _Recorder()
+        details = _details(method)
+        interceptor.intercept_unary_stream(rec, details, object())
+        assert rec.last_details.timeout is None, \
+            f"long-lived stream {method} must not receive a timeout"
+
+
+def test_interceptor_adds_timeout_to_finite_streams():
+    """Finite server-streaming RPCs (read, list) should receive the timeout."""
+    interceptor = RequestTimeoutInterceptor(timeout_s=5.0)
+    for method in [
+        "/io.streamnative.oxia.proto.OxiaClient/Read",
+        "/io.streamnative.oxia.proto.OxiaClient/List",
+    ]:
+        rec = _Recorder()
+        details = _details(method)
+        interceptor.intercept_unary_stream(rec, details, object())
+        assert rec.last_details.timeout == 5.0, \
+            f"finite stream {method} should receive the default timeout"
+
+
+def test_connection_pool_wires_interceptor():
+    """ConnectionPool created with request_timeout_ms must install the
+    interceptor."""
+    from oxia.internal.connection_pool import ConnectionPool
+
+    pool = ConnectionPool(request_timeout_ms=2_000)
+    assert len(pool._interceptors) == 1
+    assert isinstance(pool._interceptors[0], RequestTimeoutInterceptor)
+    assert pool._interceptors[0]._timeout_s == 2.0
+
+
+def test_connection_pool_no_interceptor_by_default():
+    from oxia.internal.connection_pool import ConnectionPool
+
+    pool = ConnectionPool()
+    assert pool._interceptors == []


### PR DESCRIPTION
Adds a new \`request_timeout_ms\` parameter to \`Client\` (default 30 000 ms, matching the Java SDK) that bounds the deadline on unary and finite server-streaming RPCs.

**Applied to:** \`put\`, \`delete\`, \`delete_range\`, \`get\`, \`list\`, \`create_session\`, \`keep_alive\`, \`close_session\`

**Exempted (long-lived streams):** \`get_shard_assignments\`, \`get_notifications\`, \`get_sequence_updates\`, \`range_scan\`

## Implementation

Uses a gRPC client interceptor installed on the channel, so the per-RPC timeout is applied uniformly without modifying the generated betterproto2 stub. Explicit timeouts set by callers are preserved (the interceptor only fills in defaults when none is set).

On timeout, callers get a \`grpc.RpcError\` with \`StatusCode.DEADLINE_EXCEEDED\`.

## Test plan

- [x] Unit tests for \`RequestTimeoutInterceptor\` behavior (adds/respects timeouts, skips long-lived streams, adds to finite streams)
- [x] Unit tests for \`ConnectionPool\` wiring (with/without timeout)
- [x] Full test suite passes (41 unit + 23 integration)